### PR TITLE
Add aerodrome data for Sir Seretse Khama Airport

### DIFF
--- a/docs/Aerodromes/Botswana/Sir Seretse Khama (FBSK)/aerodrome.md
+++ b/docs/Aerodromes/Botswana/Sir Seretse Khama (FBSK)/aerodrome.md
@@ -1,0 +1,47 @@
+# Aerodrome Data
+
+Sir Seretse Khama International Airport (IATA: GBE, ICAO: FBSK) located 15 kilometres (9 mi) north of downtown Gaborone, is the main international airport of the capital city of Botswana. The airport is named after Sir Seretse Khama, the first president of Botswana.
+
+## Aerodrome Details
+
+| Sir Seretse Khama    |                           |
+| :---------: | :----------------------------------: |
+| ICAO | FBSK |
+| IATA | GBE |
+| Elevation | 3299ft |
+| Transition Altitude | 7000ft |
+| Transition Level | By ATC |
+| Mag Variation | 17º W |
+
+## Declared Distances
+
+| Runway | Course | TORA | TODA | ASDA | LDA | Remarks |
+| :---------: | :---------: | :---------: | :---------: | :---------: | :---------: | :---------: |
+| 08    | 079º    | 4000     | 4000     | 4060     | 4000    | - |
+| 26    | 259º    | 4000     | 4000     | 4060     | 4000    | - |
+
+## Radio Navigation & Landing Aids
+
+| Type | ID | Frequency | Remarks | 
+| :---------: | :---------: | :---------: | :---------: |
+| VOR DME | GSV | 114.000 | - | 
+| ILS LOC | GBW | 109.900 | APP COURSE 079º | 
+
+## Aprons 
+
+| Apron | Stands | Entry/Exit Point | Remarks |
+| :---------: | :---------: | :---------: | :---------: |
+| Apron A | 1 - 6; A1 - A2 | Twy L, E or F  | - |
+| Cargo Apron | K1 - K5 | Twy K | - |
+| GA Apron/Maintenance | - | Twy N | - |
+| Debswana Apron | - | Twy M | - |
+
+## ATS Frequencies
+
+| Position    | Callsign | Frequency | Remarks |
+| :---------: | :---------: | :---------: | :---------: |
+| FBSK_ATIS  | Khama ATIS | 126.600 | - |
+| FBSK_GND   | Khama Ground | 121.950 | - |
+| FBSK_TWR   | Khama Tower | 118.300 | - |
+| FBSK_APP   | Gaborone Approach | 128.200 | - |
+| FBGR_CTR   | Gaborone Control | 131.500   | - |


### PR DESCRIPTION
Added detailed aerodrome information for Sir Seretse Khama International Airport, including aerodrome details, declared distances, radio navigation aids, aprons, and ATS frequencies.