### PR TITLE
Add aerodrome data for Lagos (DNMM)

### DIFF
--- a/docs/Aerodromes/Nigeria/Lagos (DNMM)/aerodrome.md
+++ b/docs/Aerodromes/Nigeria/Lagos (DNMM)/aerodrome.md
@@ -4,7 +4,7 @@ Murtala Muhammed International Airport is an international airport located in Ik
 
 ## Aerodrome Details
 
-| Murtaka Muhammed |                           |
+| Murtaka Muhammed |  |
 | :---------: | :----------------------------------: |
 | ICAO | DNMM |
 | IATA | LOS |
@@ -17,7 +17,7 @@ Murtala Muhammed International Airport is an international airport located in Ik
 
 | Runway | Course | TORA | TODA | ASDA | LDA | Remarks |
 | :---------: | :---------: | :---------: | :---------: | :---------: | :---------: | :---------: |
-| 18L   | 181º     | 2745     | 2745     | 2805     | 2745    | - |
+| 18L    | 181º    | 2745     | 2745     | 2805     | 2745    | - |
 | 36R    | 001º    | 2745     | 2745     | 2788     | 2745    | - |
 | 18R    | 181º    | 3900     | 3900     | 4020     | 3900    | - |
 | 36L    | 001º    | 3900     | 3900     | 4020     | 3900    | - |
@@ -54,4 +54,3 @@ Murtala Muhammed International Airport is an international airport located in Ik
 | DNKK_APP    | Lagos Approach | 124.700 | - |
 | DNMM_CTR    | Lagos Control  | 120.900 | - |
 | DNKK_CTR    | Kano East      | 124.100 | Bandbox |
-| DNKK_CTR    | Kano East | 125.100 | - |

--- a/docs/Aerodromes/Nigeria/Lagos (DNMM)/aerodrome.md
+++ b/docs/Aerodromes/Nigeria/Lagos (DNMM)/aerodrome.md
@@ -1,0 +1,57 @@
+# Aerodrome Data
+
+Murtala Muhammed International Airport is an international airport located in Ikeja, Lagos State, Nigeria, and is the major airport serving the entire state. The airport was initially built during World war II and is named after Murtala Muhammed (1938–1976), the fourth military ruler of Nigeria.
+
+## Aerodrome Details
+
+| Murtaka Muhammed |                           |
+| :---------: | :----------------------------------: |
+| ICAO | DNMM |
+| IATA | LOS |
+| Elevation | 138ft |
+| Transition Altitude | 3500ft |
+| Transition Level | FL50 |
+| Mag Variation | 2º W |
+
+## Declared Distances
+
+| Runway | Course | TORA | TODA | ASDA | LDA | Remarks |
+| :---------: | :---------: | :---------: | :---------: | :---------: | :---------: | :---------: |
+| 18L   | 181º     | 2745     | 2745     | 2805     | 2745    | - |
+| 36R    | 001º    | 2745     | 2745     | 2788     | 2745    | - |
+| 18R    | 181º    | 3900     | 3900     | 4020     | 3900    | - |
+| 36L    | 001º    | 3900     | 3900     | 4020     | 3900    | - |
+
+## Radio Navigation & Landing Aids
+
+| Type | ID | Frequency | Remarks | 
+| :---------: | :---------: | :---------: | :---------: |
+| VOR DME | LAG | 113.700 | - | 
+| NDB     | LA  | 336     | - |
+| ILS LOC | ILA | 110.300 | APP COURSE 181º |
+| ILS LOC | ILB | 108.100 | APP COURSE 181º | 
+
+## Aprons 
+
+| Apron | Stands | Entry/Exit Point | Remarks |
+| :---------: | :---------: | :---------: | :---------: |
+| International Apron | C11 - C24; D31 - D45; E51 - E66;  | Twy F1 - F5 | Apron C, D, E |
+| Domestic Terminal 1 | 1 - 6 | Twy E | - |
+| Domestic Terminal 2 | A1 - A6; B1 - B8 | Twy C | Apron A, B |
+| GA Apron | - | Twy C | - |
+| Cargo Apron | - | Twy A | - |
+| Military Apron | - | Twy C | - |
+
+## ATS Frequencies
+
+| Position    | Callsign | Frequency | Remarks |
+| :---------: | :---------: | :---------: | :---------: |
+| DNMM_ATIS   | Lagos ATIS     | 123.800 | - |
+| DNMM_DEL    | Lagos Delivery | 119.100 | EVENTS ONLY |
+| DNMM_GND    | Lagos Ground   | 121.900 | - |
+| DNMM_E_GND  | Lagos Ground   | 121.100 | EVENTS ONLY |
+| DNMM_TWR    | Lagos Tower    | 118.100 | - |
+| DNKK_APP    | Lagos Approach | 124.700 | - |
+| DNMM_CTR    | Lagos Control  | 120.900 | - |
+| DNKK_CTR    | Kano East      | 124.100 | Bandbox |
+| DNKK_CTR    | Kano East | 125.100 | - |


### PR DESCRIPTION
Added detailed aerodrome information for Murtala Muhammed International Airport, including aerodrome details, declared distances, radio navigation aids, aprons, and ATS frequencies.