### PR TITLE
Revise routing and restrictions for FAOR departures

### DIFF
--- a/docs/Aerodromes/South Africa/O.R. Tambo Intl (FAOR)/delivery.md
+++ b/docs/Aerodromes/South Africa/O.R. Tambo Intl (FAOR)/delivery.md
@@ -7,45 +7,46 @@
 
 | Destination/ FIR Exit     | Routing                                    | Restrictions          | Remarks                          |
 |--------------------------|--------------------------------------------|-----------------------|:----------------------------------:|
+| EPSEK                    | EGMENT UQ2 EPSEK                           | Jets (Runway 03)      |  -                                |
 | ETMIT                    | NESAN UQ40 EVIPI UQ16 ETMIT                | Jets (Runway 03)      |  -                                |
 | ETMIT                    | VASUR UQ41 EVIPI UQ16 ETMIT                | Turboprop/Runway 21   |  -                                |
-| ETOSA                    | VASUR UQ24 ETOSA                           | *                     |   -              |
-| FABL (All)               | HGV UZ16 NEVEN UQ9 NIDIG UZ36 BLV          | Runway 21             |     -                             |
-| FABL (Jet)               | APDAK NEVEN UQ9 NIDIG UZ36 BLV             | Runway 03             |        -                          |
-| FABL (Turboprop)         | GAV U/W95 BLV                              | Runway 03             |                     -             |
-| FACT                     | RAGUL (GAV UTEBA) UQ10 CSV UZ26 ERDAS      | Turboprop      | Q10 - FL200 TO FL245                   |
-| FAEL                     | APDAK (GEROX) UQ7 AXOXI ELV                | Runway 21        | Q7 - FL200 TO FL245                   |
-| FAGG                     | OVALA UZ18 (HGV UZ16) NEVEN UQ9 XALIN GRV  | Runway 21      | Q9 - FL200 TO FL245                   |
+| ETOSA                    | VASUR UQ24 ETOSA                           | *                     |   -                               |
+| FABL (Jet)               | APDAK NEVEN UQ9 NIDIG BLV                  | Runway 03             | CONTINGENCY ROUTE DUE TO NOTAM A0577/26 |
+| FABL (Turboprop)         | GAV WMV BLV                                | Runway 03             |                     -             |
+| FABL (All)               | HGV UZ16 NEVEN UQ9 NIDIG BLV               | Runway 21             | CONTINGENCY ROUTE DUE TO NOTAM A0577/26 |
+| FACT                     | RAGUL (GAV UTEBA) UQ10 DUMDO UZ26 ERDAS    | (Turboprop)           | Q10 - FL200 TO FL245              |
+| FAEL                     | APDAK (GEROX) UQ7 AXOXI ELV                | (Runway 21)           | Q7 - FL200 TO FL245               |
+| FAGG                     | OVALA UZ18 (HGV UZ16) NEVEN UQ9 XALIN GRV  | (Runway 21)           | Q9 - FL200 TO FL245               |
 | FAHS                     | EGMEN ANVIT HSV                            | *                     |    -                              |
-| FAKM                     | RAGUL (GAV UTEBA) UQ10 APMIN APDUR KYV     | Turboprop             |     -                             |
-| FAKN                     | EXOBI UT122 ESVEV UZ36 TILIR PKV           | *                     |      -                            |
+| FAKM                     | RAGUL (GAV UTEBA) UQ10 APMIN APDUR KYV     | (Turboprop)           |     -                             |
+| FAKN                     | EXOBI ESVEV TILIR PKV                      | *                     | CONTINGENCY ROUTE DUE TO NOTAM A0577/26 |
 | FALE                     | APDAK UQ48 APMAT                           | *                     |       -                           |
 | FALM                     | NESAN UQ1 IMKUP LTV                        | Jets (Runway 03)      |        -                          |
 | FALM                     | VASUR UZ23 IMKUP LTV                       | Turboprop/Runway 21   |         -                         |
 | FAMG                     | APDAK UQ7 (HGV UZ17) GEROX UQ28 GETOK      | Runway 21             |          -                        |
-| FAPE                     | (HGV UZ16) OVALA UZ18 NEVEN UQ8 ALKAT PEV  | Runway 21        | Q8 - FL200 TO FL245                   |
+| FAPE                     | (HGV UZ16) OVALA UZ18 NEVEN UQ8 ALKAT PEV  | Runway 21             | Q8 - FL200 TO FL245               |
 | FAPH                     | EGMEN UQ2 XATNU PHV                        | *                     |           -                       |
-| FAPM                     | APDAK UQ7 (HGV UZ17) GEROX UQ28 TESUN LYV UG853 PMV | Runway 21 |                -                  |
+| FAPM                     | APDAK UQ7 (HGV UZ17) GEROX UQ28 TESUN LYV PMV | Runway 21          |                -                  |
 | FAPP                     | NESAN UQ1 IMKUP PPV                        | *                     |            -                      |
 | FAPP                     | VASUR UZ23 IMKUP PPV                       | Turboprop/Runway 21   |       -                           |
-| FARB                     | APDAK UQ48 AVAVA UZ8 RBV                   | *                     |        -                          |
+| FARB                     | APDAK UQ48 AVAVA ETMAL OKLEP               | *                     |        -                          |
 | FASS                     | RAGUL UZ6 UNGEK SSV                        | FAR75                 |         -                         |
 | FASZ                     | EGMEN UMVET UTREX                          |                       |         -                         |
-| FAUP                     | RAGUL UZ6 UNGEK SSV UG465 UPV              | FAR75                 |          -                        |
+| FAUP                     | RAGUL UZ6 UNGEK SSV UPV                    | FAR75                 |          -                        |
 | FAUT                     | APDAK (GEROX) UQ7 OKBUS DCT                | Runway 21             |           -                       |
-| FAVG                     | (APDAK UQ7) GEROX UQ28 GETOK PMV TGV FAVG  | Runway 21             |            -                      |
+| FAVG                     | (APDAK UQ7) GEROX UQ28 GETOK PMV EPRIB FAVG | Runway 21            |            -                      |
 | FBSK                     | VASUR UQ24 DUSLI ETOSA GBV                 | *                     |             -                     |
 | FDMS                     | EXOBI UQ4 VMS (IXESU)                      | *                     |         -                         |
 | FDSK                     | EXOBI UQ4 DUKRA VSK                        | *                     |          -                        |
 | FXMM                     | (HGV UZ16) OVALA UZ18 NEVEN UQ8 ATUXO MZV  | Runway 21             |           -                       |
-| GWV                      | NESAN UQ1 IMKUP UQ6 GWV                    | *                     |            -             |
-| GWV                      | VASUR UZ23 IMKUP UQ6 GWV                   | Turboprop/Runway 21   |             -                     |
-| OKTEL                    | RAGUL UZ6 AVUSA UQ11 OKTEL                 | FAR75                 |             -                     |
-| ORNAD                  | EXOBI UT122 ORNAD                          | *                     |            -   |
-| RUDAS                   | VASUR UZ21 ITROL UQ25 RUDAS                | *                     |           -              |
+| OKMUX                    | NESAN UQ1 IMKUP UQ6 OKMUX                  | *                     |            -                      |
+| OKMUX                    | VASUR UZ23 IMKUP UQ6 OKMUX                 | Turboprop/Runway 21   |             -                     |
+| OKTEL                    | RAGUL UZ6 AVUSA OKTEL                      | FAR75                 | CONTINGENCY ROUTE DUE TO NOTAM A0577/26 |
+| ORNAD                    | EXOBI ORNAD                                | *                     | CONTINGENCY ROUTE DUE TO NOTAM A0577/26 |
+| RUDAS                    | VASUR UZ21 ITROL UQ25 RUDAS                | *                     |           -                       |
 | TAVLA                    | NESAN UQ1 TAVLA                            | Jets (Runway 03)      |           -                       |
-| TAVLA                  | VASUR UZ23 IMKUP UQ1 TAVLA                 | Jets/Turboprop Runway 21 |          -        |
-| TEVAP                    | EXOBI UT122 ESVEV UZ36 TEVAP               |                       |           -             |
+| TAVLA                    | VASUR UZ23 IMKUP UQ1 TAVLA                 | Jets/Turboprop Runway 21 |          -                     |
+| TEVAP                    | EXOBI UT122 ESVEV TEVAP                    |                       | CONTINGENCY ROUTE DUE TO NOTAM A0577/26 |
 
 
 ## Departure Procedures
@@ -53,12 +54,21 @@
 !!! warning
     Only SIDs which are currently in operation are listed below. SIDs which are suspended will require pilots to instead be given Runway Track.
 
-Runway 03L/R
+Runway 03L
 
 | Fix | SID | Initial Climb | Remarks |
 | :---------: | :---------: | :---------: | :---------: |
+| APDAK | APDAK1B | FL110 | - |
 | GAV, NESAN, VASUR, RAGUL | RWY TRK | 8000ft | - |
-| EGMEN, APDAK, EXOBI| RWY TRK | FL90 | - |
+| EGMEN, EXOBI | RWY TRK | FL90 | - |
+
+Runway 03R
+
+| Fix | SID | Initial Climb | Remarks |
+| :---------: | :---------: | :---------: | :---------: |
+| APDAK | RWY TRK | FL110 | - |
+| GAV, NESAN, VASUR, RAGUL | RWY TRK | 8000ft | - |
+| EGMEN, EXOBI | RWY TRK | FL90 | - |
 
 Runway 21R
 


### PR DESCRIPTION
Updated routing and restrictions for various destinations from FAOR, including contingency routes due to NOTAM A0577/26. 
Also included the new APDAK1B.