### PR TITLE
Fix broken image links blocking GitHub Pages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 
 # Basic Jekyll gitignores (synchronize to Jekyll.gitignore)
 _site/
+
+# MkDocs build output
+site/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata

--- a/docs/Aerodromes/Kenya/Jomo Kenyatta (HKJK)/ground.md
+++ b/docs/Aerodromes/Kenya/Jomo Kenyatta (HKJK)/ground.md
@@ -32,10 +32,10 @@ Stands F1 thru F9, J1 thru J9 and 4 thru 21 are nose-in stands and **pushback is
 At Nairobi, Apron 1 operates with a one way system in and out, depending on the runway direction.
 
 Runway 06: Taxi out via J, K Taxi in via H, M
-![Runway 06 config](apron06.png)
+<!-- TODO: Add apron06.png image for Runway 06 config -->
 
 Runway 24: Taxi out via H, M Taxi in via J, K
-![Runway 24 config](apron24.png)
+<!-- TODO: Add apron24.png image for Runway 24 config -->
 
 By default, all aircraft should be taxiied to the full length holding point unless otherwise requested by a pilot. 
 During runway 06 operations, there are two shortcut lanes from G to K that pilots can take. These can be used for sequencing and should be coordinated.

--- a/docs/Aerodromes/Kenya/Jomo Kenyatta (HKJK)/ground.md
+++ b/docs/Aerodromes/Kenya/Jomo Kenyatta (HKJK)/ground.md
@@ -32,10 +32,14 @@ Stands F1 thru F9, J1 thru J9 and 4 thru 21 are nose-in stands and **pushback is
 At Nairobi, Apron 1 operates with a one way system in and out, depending on the runway direction.
 
 Runway 06: Taxi out via J, K Taxi in via H, M
-<!-- TODO: Add apron06.png image for Runway 06 config -->
+
+!!! info "Diagram pending"
+    Apron 1 Runway 06 configuration diagram will be added in a future update.
 
 Runway 24: Taxi out via H, M Taxi in via J, K
-<!-- TODO: Add apron24.png image for Runway 24 config -->
+
+!!! info "Diagram pending"
+    Apron 1 Runway 24 configuration diagram will be added in a future update.
 
 By default, all aircraft should be taxiied to the full length holding point unless otherwise requested by a pilot. 
 During runway 06 operations, there are two shortcut lanes from G to K that pilots can take. These can be used for sequencing and should be coordinated.

--- a/docs/General/Resources/Software/Audio for VATSIM - Controller.md
+++ b/docs/General/Resources/Software/Audio for VATSIM - Controller.md
@@ -20,14 +20,14 @@ Our resources page, where you can find the Audio for VATSIM download link can be
 - Set a Push-To-Talk (PTT) bind
 - Save your changes by pressing 'Apply all' on the bottom right
 
-![Audio for VATSIM settings](../img/AFVSettings.png)
+![Audio for VATSIM settings](img/AFVSettings.png)
 
 ## Connecting and Listening to ATC
 
 - Open Audio for VATSIM, if setup correctly and connected to VATSIM you will be able to connect by pressing the 'Connect' button.
 - Click 'RX' (receive) to listen in the frequency.
-![AFV Controlling 1 - RX a Frequency](../img/AFVControlling-1.png)
+![AFV Controlling 1 - RX a Frequency](img/AFVControlling-1.png)
 - Click 'TX' (transmit) to transmit on the frequency. You will still need to utilise your Push-To-Talk key.
-![AFV Controlling 2 - TX a Frequency](../img/AFVControlling-2.png)
+![AFV Controlling 2 - TX a Frequency](img/AFVControlling-2.png)
 
 Still having issues with TrackAudio? Feel free to ask for help in one of our channels in the VATSSA Discord server which can be found in the [VATSIM Community Server's](https://community.vatsim.net/)

--- a/docs/New-Controllers/Observing Guide/Audio for VATSIM Client - Observer.md
+++ b/docs/New-Controllers/Observing Guide/Audio for VATSIM Client - Observer.md
@@ -27,7 +27,7 @@ Our resources page, where you can find the Audio for VATSIM download link can be
 - Open Audio for VATSIM, if setup correctly and connected to VATSIM you will be able to connect by pressing the 'Connect' button.
 - Once connected, press the `+` button to Add a Station.
 - Type in the station you want to observe, in this case we have `FACT_GND`.
-![AFV Observing 2 - Adding a Station](../img/AFVObserving-1.png)
+<!-- TODO: Add AFVObserving-1.png image for Adding a Station -->
 - Click 'RX' (receive) to listen on the frequency.
 ![AFV Observing 3 - RX a Frequency](../img/AFVObserving-2.png)
 

--- a/docs/New-Controllers/Observing Guide/Audio for VATSIM Client - Observer.md
+++ b/docs/New-Controllers/Observing Guide/Audio for VATSIM Client - Observer.md
@@ -27,7 +27,7 @@ Our resources page, where you can find the Audio for VATSIM download link can be
 - Open Audio for VATSIM, if setup correctly and connected to VATSIM you will be able to connect by pressing the 'Connect' button.
 - Once connected, press the `+` button to Add a Station.
 - Type in the station you want to observe, in this case we have `FACT_GND`.
-<!-- TODO: Add AFVObserving-1.png image for Adding a Station -->
+  <!-- TODO: Add AFVObserving-1.png image for Adding a Station -->
 - Click 'RX' (receive) to listen on the frequency.
 ![AFV Observing 3 - RX a Frequency](../img/AFVObserving-2.png)
 


### PR DESCRIPTION
## Summary

- **Fix 6 broken image references** that cause `mkdocs build --strict` to fail, which blocks the `deploy-github-pages` workflow from deploying to GitHub Pages
- **Add `site/` to `.gitignore`** — the existing gitignore was from a Jekyll template and only ignored `_site/`, not the MkDocs build output directory

## Details

The deploy workflow uses `mkdocs build --strict`, which treats warnings as errors. Several recently merged PRs introduced broken image links:

| File | Issue | Fix |
|---|---|---|
| `Audio for VATSIM - Controller.md` | 3 images referenced as `../img/` but files are in `img/` | Corrected relative paths |
| `Jomo Kenyatta (HKJK)/ground.md` | `apron06.png` and `apron24.png` never committed | Replaced with TODO comments |
| `Audio for VATSIM Client - Observer.md` | `AFVObserving-1.png` never committed | Replaced with TODO comment |

> **Note:** 3 image files (`apron06.png`, `apron24.png`, `AFVObserving-1.png`) were never added to the repo. They should be created and committed in a follow-up to restore that visual content.

## Impact

Once merged, this will unblock deployment and **all pending content** from today's merged PRs (#241, #249, #250, #252, #254, #255, #256, #257, #258) will go live.

## Test plan

- [x] `mkdocs build --strict` passes locally with zero warnings

https://claude.ai/code/session_017wvb1tYY93sat5UBw8QkGF