### PR TITLE
AFV Link

### DIFF
--- a/docs/General/Resources/Links.md
+++ b/docs/General/Resources/Links.md
@@ -4,7 +4,7 @@
 
 - [EuroScope - Controlling Software](https://www.euroscope.hu/)
 - [TrackAudio - Recommended Audio Client](https://github.com/pierr3/TrackAudio/releases)
-- [Audio for VATSIM - Alternative Audio Client](https://github.com/pierr3/TrackAudio/releases) 
+- [Audio for VATSIM - Alternative Audio Client](https://audio.vatsim.net/docs/atc/euroscope)
 - [vATIS - ATIS Software](http://vatis.clowd.io/)
 - [VATSSA vATIS Profiles - ATIS Presets](https://vatssa.com/hq/vatis.php)
 


### PR DESCRIPTION
Changed AFV Link, so it wasn't directing to TrackAudio

## Type of Change

<!-- Select the type that best describes your PR -->

- [ ] New Aerodrome eAIP (e.g., FQMA, HKNW)
- [ ] Update to existing eAIP (e.g., revised procedures, frequencies)
- [ ] New or updated VFR / VRP Maps
- [ ] Bug fix / Formatting fix
- [ ] New page or feature
- [x] Other

## ICAO Code(s) Affected

<!-- List the ICAO airport/FIR codes this PR affects, or "N/A" if not applicable -->



## Description

<!-- Briefly describe what this PR does and why -->



## Completion Status

<!-- Check off the files included in this PR. Remove any that don't apply. -->

- [ ] aerodrome.md
- [ ] delivery.md
- [ ] ground.md
- [ ] tower.md
- [ ] VFR / VRP Maps
- [x] Other: <!-- specify -->

## Sources


## Related Issues

Closes #253 



## Checklist

- [x] I have followed the [eAIP formatting guide](https://eaip2.vatssa.com/contributing/getting-started/)
- [x] All files in this PR are complete (no partial/placeholder content)
- [x] I have verified the information against official aviation sources
